### PR TITLE
Update DiscordWebhook.php

### DIFF
--- a/src/Webhook/DiscordWebhook.php
+++ b/src/Webhook/DiscordWebhook.php
@@ -60,6 +60,7 @@ class DiscordWebhook
         curl_setopt($ch, CURLOPT_POSTFIELDS, json_encode($content));
         curl_setopt($ch, CURLOPT_RETURNTRANSFER, true);
         curl_setopt($ch, CURLOPT_HEADER, true);
+        curl_setopt($ch, CURLOPT_HTTPHEADER, ['content-type: application/json']);
         curl_exec($ch);
         $code = curl_getinfo($ch, CURLINFO_HTTP_CODE);
         curl_close($ch);


### PR DESCRIPTION
Added `Content-Type` header. Discord won't process the request without it, declares it as an empty message.